### PR TITLE
Allow for `exclude_matches` in content scripts

### DIFF
--- a/manifest/content-script.ts
+++ b/manifest/content-script.ts
@@ -1,5 +1,9 @@
 export type ManifestContentScript = {
   matches: string[]
+  /**
+   * https://developer.chrome.com/docs/extensions/mv3/content_scripts/#matchAndGlob
+   */
+  exclude_matches?: string[]
   js?: string[]
 
   css?: string[]


### PR DESCRIPTION
ref: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#matchAndGlob